### PR TITLE
Fix duplicated dependency array in ICS data refresh hook

### DIFF
--- a/src/contexts/DataContext.jsx
+++ b/src/contexts/DataContext.jsx
@@ -103,7 +103,7 @@ export const DataProvider = ({ children }) => {
     console.error('ICS Aggregation Failed:', e);
     toast({ title: 'ICS Aggregation Failed', description: e.message || 'Unexpected error', variant: 'destructive' });
   }
-}, [toast]);, [toast]);
+  }, [toast]);
 
   useEffect(() => {
     const loadData = () => {


### PR DESCRIPTION
## Summary
- Fix `refreshAggregatedIcsData` hook by removing stray extra dependency array

## Testing
- `npm run build`
- `node --input-type=module - <<'NODE'
class LocalStorage {
  constructor() { this.store = {}; }
  getItem(k) { return Object.prototype.hasOwnProperty.call(this.store, k) ? this.store[k] : null; }
  setItem(k, v) { this.store[k] = String(v); }
  removeItem(k) { delete this.store[k]; }
}

global.window = { localStorage: new LocalStorage() };
global.localStorage = global.window.localStorage;

import('./src/services/dataService.js').then(ds => {
  ds.initializeDefaultData();
  const allData = {
    applications: ds.getApplications(),
    technologies: ds.getTechnologies(),
    infrastructure: ds.getInfrastructure(),
    securityControls: ds.getSecurityControls(),
    networkComponents: ds.getNetworkComponents(),
    dataDictionary: ds.getDataDictionary(),
    relations: ds.getRelations(),
    networkDependencies: ds.getNetworkDependencies(),
    dataFlows: ds.getDataFlows(),
  };
  const { components, edges } = ds.runIcsAggregation(allData, ds.getIcsLevelRules(), ds.getIcsZones());
  console.log('components', components.length, 'edges', edges.length);
}).catch(err => {
  console.error(err);
});
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689851c8db488330bdc70e89d6ba99b0