### PR TITLE
Refresh ICS data when components list empty

### DIFF
--- a/src/pages/ICSLevels.jsx
+++ b/src/pages/ICSLevels.jsx
@@ -53,6 +53,12 @@ const ICSLevels = () => {
   const [editingNote, setEditingNote] = useState(null);
 
   useEffect(() => {
+    if (!aggregatedIcsComponents || aggregatedIcsComponents.length === 0) {
+      refreshAggregatedIcsData();
+    }
+  }, [aggregatedIcsComponents, refreshAggregatedIcsData]);
+
+  useEffect(() => {
     setSyncStatus(getAggregatorSyncStatus(aggregatedIcsComponents));
   }, [aggregatedIcsComponents]);
 


### PR DESCRIPTION
## Summary
- Refresh aggregated ICS data on page load when component list is empty

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68985c361a2c83309219efae4e8c7470